### PR TITLE
Handle SASS debug info

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -58,7 +58,7 @@
     }
     elem.setAttribute('style', newStyle.join(';'));
   }
-  var cssPattern = /\s*(.*?)\s*{(.*?)}/g,
+  var cssPattern = /\s*(.*?)\s*{(.*?)}+/g,
       matchPosition = /\.*?position:.*?sticky.*?;/,
       getTop = /\.*?top:(.*?);/,
       toObserve = [];


### PR DESCRIPTION
CSS compiled by SASS has a debug info declaration which has nested braces. This commit makes the regex consume the second closing brace so it doesn't get parsed as part of the following selector.

E.g.

``` css
@media -sass-debug-info{filename{font-family:file\:\/\/\/Users\/turadg\/Code\/Ruby\/app-rails\/app\/assets\/stylesheets\/objectives\/objectives\.css\.scss}line{font-family:\000032}}body.objectives.show #sidebar {  top: 15px;  position: sticky; }
```

was causing DOM error 12 because `parse(css)` was passing `}body.objectives.show #sidebar` to `qSA` (querySelectorAll).
