### PR TITLE
Case insensitive RegEx match

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -71,14 +71,14 @@
     }
     elem.setAttribute('style', newStyle.join(';'));
   }
-  var cssPattern = /\s*(.*?)\s*{(.*?)}+/gi,
+  var cssPattern = /\s*(.*?)\s*{(.*?)}+/g,
       matchPosition = /\.*?position:.*?sticky.*?;/i,
       getTop = /\.*?top:(.*?);/i,
       toObserve = [];
 
   function parse(css) {
     var matches;
-    css = css.replace(/(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gmi, '').replace(/\n|\r/gi, '');
+    css = css.replace(/(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gm, '').replace(/\n|\r/g, '');
 
     while((matches = cssPattern.exec(css)) !== null) {
       var selector = matches[1];


### PR DESCRIPTION
Don't work on uppercase rules: HEADER{POSITION:STICKY;TOP:0;}

Also don't work on non-semicoloned rule: header {position:sticky}
But it's not so important and it would be harder to fix it...
