### PR TITLE
Handle nested braces

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -77,7 +77,7 @@
     }
     elem.setAttribute('style', newStyle.join(';'));
   }
-  var cssPattern = /\s*(.*?)\s*{(.*?)}+/g,
+  var cssPattern = /\s*([^{}]+?)\s*{([^{}]+?)}+/g,
       matchPosition = /\.*?position:.*?sticky.*?;/i,
       getTop = /\.*?top:(.*?);/i,
       toObserve = [];


### PR DESCRIPTION
This solves #11, as well as a similar bug detecting sticky selectors immediately following `keyframes`.